### PR TITLE
Fix example SSE bucket policy

### DIFF
--- a/doc_source/UsingKMSEncryption.md
+++ b/doc_source/UsingKMSEncryption.md
@@ -46,7 +46,7 @@ To require server\-side encryption of all objects in a particular Amazon S3 buck
 ```
  1. {
  2.    "Version":"2012-10-17",
- 3.    "Id":"PutObjPolicy"
+ 3.    "Id":"PutObjPolicy",
  4.    "Statement":[{
  5.          "Sid":"DenyUnEncryptedObjectUploads",
  6.          "Effect":"Deny",


### PR DESCRIPTION

*Issue #, if available:*
N/A
*Description of changes:*
The example policy is missing a comma after the `Id` key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
